### PR TITLE
Honor locale settings

### DIFF
--- a/MNCalendarView/MNCalendarView.m
+++ b/MNCalendarView/MNCalendarView.m
@@ -97,6 +97,7 @@
   _calendar = calendar;
   
   self.monthFormatter = [[NSDateFormatter alloc] init];
+  self.monthFormatter.locale = [calendar locale];
   self.monthFormatter.calendar = calendar;
   [self.monthFormatter setDateFormat:@"MMMM yyyy"];
 }
@@ -119,7 +120,8 @@
   
   NSDateFormatter *formatter = [[NSDateFormatter alloc] init];
   formatter.calendar = self.calendar;
-  
+  formatter.locale = self.calendar.locale;
+
   self.weekdaySymbols = formatter.shortWeekdaySymbols;
   
   [self.collectionView reloadData];

--- a/MNCalendarView/MNCalendarView.m
+++ b/MNCalendarView/MNCalendarView.m
@@ -142,24 +142,15 @@
 - (NSDate *)firstVisibleDateOfMonth:(NSDate *)date {
   date = [date mn_firstDateOfMonth:self.calendar];
   
-  NSDateComponents *components =
-    [self.calendar components:NSYearCalendarUnit|NSMonthCalendarUnit|NSDayCalendarUnit|NSWeekdayCalendarUnit
-                fromDate:date];
-  
-  return
-    [[date mn_dateWithDay:-((components.weekday - 1) % self.daysInWeek) calendar:self.calendar] dateByAddingTimeInterval:MN_DAY];
+  NSDateComponents *components = [self.calendar components:NSWeekdayCalendarUnit fromDate:date];
+  return [date dateByAddingTimeInterval:-MN_DAY * ((components.weekday - self.calendar.firstWeekday + self.daysInWeek) % self.daysInWeek)];
 }
 
 - (NSDate *)lastVisibleDateOfMonth:(NSDate *)date {
   date = [date mn_lastDateOfMonth:self.calendar];
-  
-  NSDateComponents *components =
-    [self.calendar components:NSYearCalendarUnit|NSMonthCalendarUnit|NSDayCalendarUnit|NSWeekdayCalendarUnit
-                     fromDate:date];
-  
-  return
-    [date mn_dateWithDay:components.day + (self.daysInWeek - 1) - ((components.weekday - 1) % self.daysInWeek)
-                calendar:self.calendar];
+
+  NSDateComponents *components = [self.calendar components:NSWeekdayCalendarUnit fromDate:date];
+  return [date dateByAddingTimeInterval:MN_DAY * (self.daysInWeek - 1 - ((components.weekday - self.calendar.firstWeekday + self.daysInWeek) % self.daysInWeek))];
 }
 
 - (void)applyConstraints {
@@ -240,7 +231,7 @@
                                                 forIndexPath:indexPath];
     
     cell.backgroundColor = self.collectionView.backgroundColor;
-    cell.titleLabel.text = self.weekdaySymbols[indexPath.item];
+    cell.titleLabel.text = self.weekdaySymbols[(NSUInteger) ((indexPath.item + self.calendar.firstWeekday - 1) % self.daysInWeek)];
     cell.separatorColor = self.separatorColor;
     return cell;
   }
@@ -252,7 +243,7 @@
   NSDate *monthDate = self.monthDates[indexPath.section];
   NSDate *firstDateInMonth = [self firstVisibleDateOfMonth:monthDate];
 
-  NSUInteger day = indexPath.item - self.daysInWeek;
+  NSInteger day = indexPath.item - self.daysInWeek;
   
   NSDateComponents *components =
     [self.calendar components:NSDayCalendarUnit|NSMonthCalendarUnit|NSYearCalendarUnit
@@ -309,10 +300,10 @@
   CGFloat itemWidth  = roundf(width / self.daysInWeek);
   CGFloat itemHeight = indexPath.item < self.daysInWeek ? 30.f : itemWidth;
   
-  NSUInteger weekday = indexPath.item % self.daysInWeek;
+  NSInteger weekday = (indexPath.item + self.calendar.firstWeekday - 1) % self.daysInWeek;
   
   if (weekday == self.daysInWeek - 1) {
-    itemWidth = width - (itemWidth * (self.daysInWeek - 1));
+    itemWidth = width - itemWidth * (self.daysInWeek - 1); // use all remaining width for rightmost element
   }
   
   return CGSizeMake(itemWidth, itemHeight);

--- a/MNCalendarView/MNCalendarViewDayCell.m
+++ b/MNCalendarView/MNCalendarViewDayCell.m
@@ -37,15 +37,16 @@ NSString *const MNCalendarViewDayCellIdentifier = @"MNCalendarViewDayCellIdentif
   [self.calendar components:NSMonthCalendarUnit
                    fromDate:self.month];
   
-  self.weekday = components.weekday;
-  self.enabled = self.withinMonth = (monthComponents.month == components.month);
+  self.weekday = (NSUInteger) components.weekday;
+  self.withinMonth = (monthComponents.month == components.month);
+  self.enabled = self.withinMonth;
   self.titleLabel.text = self.withinMonth ? [@(components.day) stringValue] : @"";
 
   [self setNeedsDisplay];
 }
 
 - (void)setEnabled:(BOOL)enabled {
-  [super setEnabled:enabled && self.withinMonth];
+  [super setEnabled:(enabled && self.withinMonth)];
 
   self.titleLabel.textColor =
   self.enabled ? UIColor.darkTextColor : UIColor.lightGrayColor;
@@ -53,7 +54,7 @@ NSString *const MNCalendarViewDayCellIdentifier = @"MNCalendarViewDayCellIdentif
   self.backgroundColor =
   self.enabled ? UIColor.whiteColor :
 	  self.withinMonth ? [UIColor colorWithRed:.96f green:.96f blue:.96f alpha:1.f] :
-		  [UIColor colorWithRed:.80f green:.80f blue:.80f alpha:1.f];
+		  self.separatorColor;
 }
 
 - (void)drawRect:(CGRect)rect {
@@ -65,7 +66,7 @@ NSString *const MNCalendarViewDayCellIdentifier = @"MNCalendarViewDayCellIdentif
   
   CGSize size = self.bounds.size;
 
-  if (self.withinMonth && self.weekday != 1) {
+  if (self.withinMonth && self.weekday != self.calendar.firstWeekday) {
 	  CGFloat pixel = 1.f / [UIScreen mainScreen].scale;
       MNContextDrawLine(context,
                      CGPointMake(0, 0),

--- a/MNCalendarView/MNCalendarViewDayCell.m
+++ b/MNCalendarView/MNCalendarViewDayCell.m
@@ -15,6 +15,7 @@ NSString *const MNCalendarViewDayCellIdentifier = @"MNCalendarViewDayCellIdentif
 @property(nonatomic,strong,readwrite) NSDate *date;
 @property(nonatomic,strong,readwrite) NSDate *month;
 @property(nonatomic,assign,readwrite) NSUInteger weekday;
+@property(nonatomic,assign, readwrite) BOOL withinMonth;
 
 @end
 
@@ -37,20 +38,22 @@ NSString *const MNCalendarViewDayCellIdentifier = @"MNCalendarViewDayCellIdentif
                    fromDate:self.month];
   
   self.weekday = components.weekday;
-  self.titleLabel.text = [NSString stringWithFormat:@"%d", components.day];
-  self.enabled = monthComponents.month == components.month;
-  
+  self.enabled = self.withinMonth = (monthComponents.month == components.month);
+  self.titleLabel.text = self.withinMonth ? [@(components.day) stringValue] : @"";
+
   [self setNeedsDisplay];
 }
 
 - (void)setEnabled:(BOOL)enabled {
-  [super setEnabled:enabled];
-  
+  [super setEnabled:enabled && self.withinMonth];
+
   self.titleLabel.textColor =
   self.enabled ? UIColor.darkTextColor : UIColor.lightGrayColor;
   
   self.backgroundColor =
-  self.enabled ? UIColor.whiteColor : [UIColor colorWithRed:.96f green:.96f blue:.96f alpha:1.f];
+  self.enabled ? UIColor.whiteColor :
+	  self.withinMonth ? [UIColor colorWithRed:.96f green:.96f blue:.96f alpha:1.f] :
+		  [UIColor colorWithRed:.80f green:.80f blue:.80f alpha:1.f];
 }
 
 - (void)drawRect:(CGRect)rect {
@@ -61,14 +64,15 @@ NSString *const MNCalendarViewDayCellIdentifier = @"MNCalendarViewDayCellIdentif
   CGColorRef separatorColor = self.separatorColor.CGColor;
   
   CGSize size = self.bounds.size;
-  
-  if (self.weekday != 7) {
-    CGFloat pixel = 1.f / [UIScreen mainScreen].scale;
-    MNContextDrawLine(context,
-                      CGPointMake(size.width - pixel, pixel),
-                      CGPointMake(size.width - pixel, size.height),
-                      separatorColor,
-                      pixel);
+
+  if (self.withinMonth && self.weekday != 1) {
+	  CGFloat pixel = 1.f / [UIScreen mainScreen].scale;
+      MNContextDrawLine(context,
+                     CGPointMake(0, 0),
+                     CGPointMake(0, size.height),
+                     separatorColor,
+                     pixel);
+
   }
 }
 


### PR DESCRIPTION
- display month & day names in the NSCalendar's specific NSLocale
- honor the calendar's firstWeekday, which is typically either sunday or monday depending on world regions
- do not display days not pertaining to the current month
